### PR TITLE
i_input_tty: also try /dev/tty0

### DIFF
--- a/fbdoom/i_input_tty.c
+++ b/fbdoom/i_input_tty.c
@@ -277,7 +277,7 @@ void kbd_shutdown(void)
 static int kbd_init(void)
 {
     struct termios new_term;
-    char *files_to_try[] = {"/dev/tty", "/dev/console", NULL};
+    char *files_to_try[] = {"/dev/tty", "/dev/tty0", "/dev/console", NULL};
     int i;
     int flags;
     int found = 0;


### PR DESCRIPTION
There are slightly more virtual environments where this is necessary. This has run successfully on an Allwinner D1 SoC (RISC-V). :-)

Thank you for porting Doom! \o/